### PR TITLE
Fix #5, Changed behaviour of delete key

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -309,6 +309,12 @@ func (o *operation) readline(deadline chan struct{}) ([]rune, error) {
 				if !o.buf.Delete() {
 					o.t.Bell()
 				}
+			}
+		case CharEOT:
+			if o.buf.Len() > 0 || !o.IsNormalMode() {
+				if !o.buf.Delete() {
+					o.t.Bell()
+				}
 				break
 			}
 

--- a/operation.go
+++ b/operation.go
@@ -304,21 +304,18 @@ func (o *operation) readline(deadline chan struct{}) ([]rune, error) {
 			} else {
 				o.t.Bell()
 			}
-		case MetaDeleteKey:
-			if o.buf.Len() > 0 || !o.IsNormalMode() {
-				if !o.buf.Delete() {
-					o.t.Bell()
-				}
-			}
-		case CharEOT:
+		case MetaDeleteKey, CharEOT:
+			// on Delete key or Ctrl-D, attempt to delete a character:
 			if o.buf.Len() > 0 || !o.IsNormalMode() {
 				if !o.buf.Delete() {
 					o.t.Bell()
 				}
 				break
 			}
-
-			// treat as EOF
+			if r != CharEOT {
+				break
+			}
+			// Ctrl-D on an empty buffer: treated as EOF
 			if !o.GetConfig().UniqueEditLine {
 				o.buf.WriteString(o.GetConfig().EOFPrompt + "\n")
 			}

--- a/operation.go
+++ b/operation.go
@@ -304,7 +304,7 @@ func (o *operation) readline(deadline chan struct{}) ([]rune, error) {
 			} else {
 				o.t.Bell()
 			}
-		case CharDelete:
+		case MetaDeleteKey:
 			if o.buf.Len() > 0 || !o.IsNormalMode() {
 				if !o.buf.Delete() {
 					o.t.Bell()

--- a/terminal.go
+++ b/terminal.go
@@ -358,7 +358,7 @@ func (t *terminal) consumeANSIEscape(buf *bufio.Reader) (result readResult, err 
 		r = CharLineEnd
 	case '~':
 		if initial == '[' && data == "3" {
-			r = CharDelete // ???
+			r = MetaDeleteKey // this is the key typically labeled "Delete"
 		}
 	case 'Z':
 		if initial == '[' {

--- a/utils.go
+++ b/utils.go
@@ -46,7 +46,7 @@ const (
 	MetaBackspace
 	MetaTranspose
 	MetaShiftTab
-	CharDelete
+	MetaDeleteKey
 )
 
 type rawModeHandler struct {

--- a/utils.go
+++ b/utils.go
@@ -14,7 +14,7 @@ const (
 	CharLineStart = 1
 	CharBackward  = 2
 	CharInterrupt = 3
-	CharDelete    = 4
+	CharEOT       = 4
 	CharLineEnd   = 5
 	CharForward   = 6
 	CharBell      = 7
@@ -46,6 +46,7 @@ const (
 	MetaBackspace
 	MetaTranspose
 	MetaShiftTab
+	CharDelete
 )
 
 type rawModeHandler struct {


### PR DESCRIPTION
* Changed current delete to CharEOT, added new CharDelete key

wader notes:
Don't expect more char after ex esc rune
Kick reader even if no char is deleted