### PR TITLE
Expose a ClearScreen method

### DIFF
--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -60,6 +60,8 @@ var completer = readline.NewPrefixCompleter(
 		readline.PcItem("test"),
 	),
 	readline.PcItem("sleep"),
+	readline.PcItem("async"),
+	readline.PcItem("clear"),
 )
 
 func filterInput(r rune) (rune, bool) {

--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -178,6 +178,8 @@ func main() {
 			} else {
 				log.Println("async writes already started")
 			}
+		case line == "clear":
+			l.ClearScreen()
 		case line == "":
 		default:
 			log.Println("you said:", strconv.Quote(line))

--- a/internal/platform/utils_unix.go
+++ b/internal/platform/utils_unix.go
@@ -4,7 +4,6 @@ package platform
 
 import (
 	"context"
-	"io"
 	"os"
 	"os/signal"
 	"sync"
@@ -72,11 +71,6 @@ func GetScreenSize() (width int, height int) {
 		width, height = getWidthHeight(syscall.Stderr)
 	}
 	return
-}
-
-// ClearScreen clears the console screen
-func ClearScreen(w io.Writer) (int, error) {
-	return w.Write([]byte("\033[H"))
 }
 
 func DefaultIsTerminal() bool {

--- a/internal/platform/utils_windows.go
+++ b/internal/platform/utils_windows.go
@@ -3,7 +3,6 @@
 package platform
 
 import (
-	"io"
 	"syscall"
 )
 
@@ -36,11 +35,6 @@ func GetScreenSize() (width int, height int) {
 	height = int(info.srWindow.bottom) - int(info.srWindow.top) + 1
 	width = int(info.srWindow.right) - int(info.srWindow.left) + 1
 	return
-}
-
-// ClearScreen clears the console screen
-func ClearScreen(_ io.Writer) error {
-	return SetConsoleCursorPosition(&_COORD{0, 0})
 }
 
 func DefaultIsTerminal() bool {

--- a/operation.go
+++ b/operation.go
@@ -221,7 +221,7 @@ func (o *operation) readline(deadline chan struct{}) ([]rune, error) {
 				o.Refresh()
 			}
 		case CharCtrlL:
-			platform.ClearScreen(o.t)
+			clearScreen(o.t)
 			o.buf.SetOffset(cursorPosition{1, 1})
 			o.Refresh()
 		case MetaBackspace, CharCtrlW:
@@ -546,8 +546,4 @@ func (o *operation) refresh() {
 	if o.isPrompting {
 		o.buf.Refresh(nil)
 	}
-}
-
-func (o *operation) Clean() {
-	o.buf.Clean()
 }

--- a/readline.go
+++ b/readline.go
@@ -267,10 +267,8 @@ func (i *Instance) CaptureExitSignal() {
 	}()
 }
 
-func (i *Instance) Clean() {
-	i.operation.Clean()
-}
-
+// Write writes output to the screen, redrawing the prompt and buffer
+// as needed.
 func (i *Instance) Write(b []byte) (int, error) {
 	return i.Stdout().Write(b)
 }
@@ -302,6 +300,11 @@ func (i *Instance) DisableHistory() {
 // EnableHistory enables the saving of input lines in history.
 func (i *Instance) EnableHistory() {
 	i.operation.history.Enable()
+}
+
+// ClearScreen clears the screen.
+func (i *Instance) ClearScreen() {
+	clearScreen(i.operation.Stdout())
 }
 
 // Painter is a callback type to allow modifying the buffer before it is rendered

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package readline
 import (
 	"container/list"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 
@@ -71,6 +72,11 @@ func (r *rawModeHandler) Exit() error {
 	if err == nil {
 		r.state = nil
 	}
+	return err
+}
+
+func clearScreen(w io.Writer) error {
+	_, err := w.Write([]byte("\x1b[H\x1b[J"))
 	return err
 }
 


### PR DESCRIPTION
For parity with the original library; fixes #36.

cc @wader @dominikschulz

We no longer need platform-specific screen-clearing code, as per #2. Some of the other platform-specific utilities may be obsolete as well...

I tested this on Linux and Windows with the readline demo, and on Linux with https://github.com/gopasspw/gopass/pull/2684 using `replace` in go.mod. Everything looks OK so far.