### PR TITLE
fix #38

### DIFF
--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -167,6 +167,14 @@ func main() {
 					log.Println(line)
 				}
 			}()
+		case strings.HasPrefix(line, "echo "):
+			preArg := strings.TrimSpace(strings.TrimPrefix(line, "echo "))
+			arg := strings.TrimPrefix(preArg, "-n ")
+			out := []byte(arg)
+			if preArg == arg {
+				out = append(out, '\n')
+			}
+			l.Write(out)
 		case line == "bye":
 			goto exit
 		case line == "sleep":

--- a/runebuf.go
+++ b/runebuf.go
@@ -545,11 +545,11 @@ func (r *runeBuffer) output() []byte {
 	if r.isInLineEdge() {
 		buf.WriteString(" \b")
 	}
+	buf.WriteString("\x1b[0K") // VT100 "Clear line from cursor right", see #38
 	// cursor position
 	if len(r.buf) > r.idx {
 		buf.Write(r.getBackspaceSequence())
 	}
-	buf.WriteString("\x1b[0K") // VT100 "Clear line from cursor right", see #38
 	return buf.Bytes()
 }
 

--- a/runebuf.go
+++ b/runebuf.go
@@ -549,6 +549,7 @@ func (r *runeBuffer) output() []byte {
 	if len(r.buf) > r.idx {
 		buf.Write(r.getBackspaceSequence())
 	}
+	buf.WriteString("\x1b[0K") // VT100 "Clear line from cursor right", see #38
 	return buf.Bytes()
 }
 


### PR DESCRIPTION
Redrawing the prompt with (*runeBuffer).Print() was leaving the search menu visible. Fix this by clearing to the right of the prompt. This does not regress d9af567, i.e. text to the left of the prompt on the same line is not cleared.

cc @wader 