### PR TITLE
fix zos support

### DIFF
--- a/internal/platform/utils_unix.go
+++ b/internal/platform/utils_unix.go
@@ -1,4 +1,4 @@
-//go:build aix || darwin || dragonfly || freebsd || (linux && !appengine) || netbsd || openbsd || os400 || solaris
+//go:build aix || darwin || dragonfly || freebsd || (linux && !appengine) || netbsd || openbsd || os400 || solaris || zos
 
 package platform
 


### PR DESCRIPTION
Fixes #55. This seems pretty safe but I don't know how to actually test this. With a standard Google distribution of Go I get:

```
$ go version
go version go1.22.2 linux/amd64
$ GOOS=zos go build ./example/readline-demo/readline-demo.go 
go: unsupported GOOS/GOARCH pair zos/amd64
```

cc @wader 