### PR TITLE
Unbreak rune filtering functionality

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -100,7 +100,7 @@ func (o *operation) readline(deadline chan struct{}) ([]rune, error) {
 		keepInCompleteMode := false
 		r, err := o.t.GetRune(deadline)
 
-		if cfg := o.GetConfig(); cfg.FuncFilterInputRune != nil && err != nil {
+		if cfg := o.GetConfig(); cfg.FuncFilterInputRune != nil && err == nil {
 			var process bool
 			r, process = cfg.FuncFilterInputRune(r)
 			if !process {


### PR DESCRIPTION
Currently, the rune filtering functionality does not work since the check assumes that the reading of runes fails, which is incorrect in most circumstances when the FilterRunes function is called.

This patch flips the condition so that instead evaluates to true instead.