### PR TITLE
feat: Support selecting candidates when completion is paged

### DIFF
--- a/example/readline-paged-completion/readline-paged-completion.go
+++ b/example/readline-paged-completion/readline-paged-completion.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"strconv"
+	"strings"
+
+	"github.com/ergochat/readline"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+// A completor that will give a lot of completions for showcasing the paging functionality
+type Completor struct{}
+
+func (c *Completor) Do(line []rune, pos int) ([][]rune, int) {
+	completion := make([][]rune, 0, 10000)
+	for i := 0; i < 1000; i += 1 {
+		s := fmt.Sprintf("%s%020d", randSeq(1), i)
+		completion = append(completion, []rune(s))
+	}
+	return completion, pos
+}
+
+func main() {
+	c := Completor{}
+	l, err := readline.NewEx(&readline.Config{
+		Prompt:          "\033[31m»\033[0m ",
+		AutoComplete:    &c,
+		InterruptPrompt: "^C",
+		EOFPrompt:       "exit",
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+	for {
+		line, err := l.Readline()
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				break
+			} else {
+				continue
+			}
+		} else if err == io.EOF {
+			break
+		}
+
+		line = strings.TrimSpace(line)
+		switch {
+		default:
+			log.Println("you said:", strconv.Quote(line))
+		}
+	}
+}

--- a/example/readline-paged-completion/readline-paged-completion.go
+++ b/example/readline-paged-completion/readline-paged-completion.go
@@ -27,7 +27,14 @@ type Completor struct{}
 func (c *Completor) Do(line []rune, pos int) ([][]rune, int) {
 	completion := make([][]rune, 0, 10000)
 	for i := 0; i < 1000; i += 1 {
-		s := fmt.Sprintf("%s%020d", randSeq(1), i)
+		var s string
+		if i%2 == 0 {
+			s = fmt.Sprintf("%s%05d", randSeq(1), i)
+		} else if i%3 == 0 {
+			s = fmt.Sprintf("%s%010d", randSeq(1), i)
+		} else {
+			s = fmt.Sprintf("%s%07d", randSeq(1), i)
+		}
 		completion = append(completion, []rune(s))
 	}
 	return completion, pos

--- a/operation.go
+++ b/operation.go
@@ -124,14 +124,6 @@ func (o *operation) readline(deadline chan struct{}) ([]rune, error) {
 		}
 		isUpdateHistory := true
 
-		if o.completer.IsInPagerMode() {
-			keepInCompleteMode = o.completer.HandlePagerMode(r)
-			if !keepInCompleteMode {
-				o.buf.Refresh(nil)
-			}
-			continue
-		}
-
 		if o.completer.IsInCompleteSelectMode() {
 			keepInCompleteMode = o.completer.HandleCompleteSelect(r)
 			if keepInCompleteMode {


### PR DESCRIPTION
This resolves #65 

Upon reflection, I removed `PagerMode` in which the user could do nothing but view the pages and make paging a transparent feature under `CompleteMode` and `CompleteSelectionMode`. The benefits are:

1. The user could select a candidate from the completions to enter on the terminal, which is currently impossible. 
2. the user can continue typing and have the auto completor update completion even if the number of candidates requires pagination.

Below is a demo from the `example/readline-paged-completion` I added:


https://github.com/user-attachments/assets/7c6d858e-3046-4202-a55e-042873799b6e

