### PR TITLE
fix Home and End key behavior in tmux

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -386,9 +386,9 @@ func (t *terminal) consumeANSIEscape(buf *bufio.Reader, ansiBuf *bytes.Buffer) (
 			switch string(ansiBuf.Bytes()) {
 			case "3":
 				r = MetaDeleteKey // this is the key typically labeled "Delete"
-			case "7":
+			case "1", "7":
 				r = CharLineStart // "Home" key
-			case "8":
+			case "4", "8":
 				r = CharLineEnd // "End" key
 			}
 		}


### PR DESCRIPTION
Add support for "VT220-style function keys" (similar to the existing escape sequences for Home and End, but with a different numeral in the middle)

See discussion on #67.