### PR TITLE
add internal/platform/utils_js.go to allow building under wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a pure Go implementation of functionality comparable to [GNU Readline](h
 
 It is a fork of [chzyer/readline](https://github.com/chzyer/readline).
 
+
 * Relative to the upstream repository, it is actively maintained and has numerous bug fixes
    - See our [changelog](docs/CHANGELOG.md) for details on fixes and improvements
    - See our [migration guide](docs/MIGRATING.md) for advice on how to migrate from upstream

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 readline
 ========
 
-[![Godoc](https://godoc.org/github.com/ergochat/readline?status.svg)](https://godoc.org/github.com/ergochat/readline)
+[![Godoc](https://godoc.org/github.com/cogentcore/readline?status.svg)](https://godoc.org/github.com/cogentcore/readline)
 
 This is a pure Go implementation of functionality comparable to [GNU Readline](https://en.wikipedia.org/wiki/GNU_Readline), i.e. line editing and command history for simple TUI programs.
 
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ergochat/readline"
+	"github.com/cogentcore/readline"
 )
 
 func main() {

--- a/complete.go
+++ b/complete.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/ergochat/readline/internal/platform"
-	"github.com/ergochat/readline/internal/runes"
+	"github.com/cogentcore/readline/internal/platform"
+	"github.com/cogentcore/readline/internal/runes"
 )
 
 type AutoCompleter interface {

--- a/complete_helper.go
+++ b/complete_helper.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"strings"
 
-	"github.com/ergochat/readline/internal/runes"
+	"github.com/cogentcore/readline/internal/runes"
 )
 
 // PrefixCompleter implements AutoCompleter via a recursive tree.

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -1,6 +1,6 @@
 # Migrating
 
-ergochat/readline is largely API-compatible with the most commonly used functionality of chzyer/readline. See our [godoc page](https://pkg.go.dev/github.com/ergochat/readline) for the current state of the public API; if an API you were using has been removed, its replacement may be readily apparent.
+ergochat/readline is largely API-compatible with the most commonly used functionality of chzyer/readline. See our [godoc page](https://pkg.go.dev/github.com/cogentcore/readline) for the current state of the public API; if an API you were using has been removed, its replacement may be readily apparent.
 
 Here are some guidelines for APIs that have been removed or changed:
 

--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ergochat/readline"
+	"github.com/cogentcore/readline"
 )
 
 func usage(w io.Writer) {

--- a/example/readline-multiline/readline-multiline.go
+++ b/example/readline-multiline/readline-multiline.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	"github.com/ergochat/readline"
+	"github.com/cogentcore/readline"
 )
 
 func main() {

--- a/example/readline-paged-completion/readline-paged-completion.go
+++ b/example/readline-paged-completion/readline-paged-completion.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ergochat/readline"
+	"github.com/cogentcore/readline"
 )
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/example/readline-pass-strength/readline-pass-strength.go
+++ b/example/readline-pass-strength/readline-pass-strength.go
@@ -22,7 +22,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ergochat/readline"
+	"github.com/cogentcore/readline"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ergochat/readline
+module github.com/cogentcore/readline
 
 go 1.19
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=

--- a/history.go
+++ b/history.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ergochat/readline/internal/runes"
+	"github.com/cogentcore/readline/internal/runes"
 )
 
 type hisItem struct {

--- a/internal/platform/utils_js.go
+++ b/internal/platform/utils_js.go
@@ -1,0 +1,37 @@
+//go:build js
+
+package platform
+
+import (
+	"syscall"
+
+	"github.com/ergochat/readline/internal/term"
+)
+
+const (
+	IsWindows = false
+)
+
+func SuspendProcess() {
+}
+
+// GetScreenSize returns the width, height of the terminal or -1,-1
+func GetScreenSize() (width int, height int) {
+	width, height, err := term.GetSize(int(syscall.Stdout))
+	if err == nil {
+		return width, height
+	} else {
+		return 0, 0
+	}
+}
+
+func DefaultIsTerminal() bool {
+	return term.IsTerminal(int(syscall.Stdin)) && term.IsTerminal(int(syscall.Stdout))
+}
+
+func DefaultOnWidthChanged(f func()) {
+	DefaultOnSizeChanged(f)
+}
+
+func DefaultOnSizeChanged(f func()) {
+}

--- a/internal/platform/utils_js.go
+++ b/internal/platform/utils_js.go
@@ -5,7 +5,7 @@ package platform
 import (
 	"syscall"
 
-	"github.com/ergochat/readline/internal/term"
+	"github.com/cogentcore/readline/internal/term"
 )
 
 const (

--- a/internal/platform/utils_unix.go
+++ b/internal/platform/utils_unix.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/ergochat/readline/internal/term"
+	"github.com/cogentcore/readline/internal/term"
 )
 
 const (

--- a/internal/platform/utils_windows.go
+++ b/internal/platform/utils_windows.go
@@ -5,7 +5,7 @@ package platform
 import (
 	"syscall"
 
-	"github.com/ergochat/readline/internal/term"
+	"github.com/cogentcore/readline/internal/term"
 )
 
 const (

--- a/operation.go
+++ b/operation.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/ergochat/readline/internal/platform"
-	"github.com/ergochat/readline/internal/runes"
+	"github.com/cogentcore/readline/internal/platform"
+	"github.com/cogentcore/readline/internal/runes"
 )
 
 var (

--- a/readline.go
+++ b/readline.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/ergochat/readline/internal/platform"
+	"github.com/cogentcore/readline/internal/platform"
 )
 
 type Instance struct {

--- a/runebuf.go
+++ b/runebuf.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ergochat/readline/internal/runes"
+	"github.com/cogentcore/readline/internal/runes"
 )
 
 type runeBuffer struct {

--- a/terminal.go
+++ b/terminal.go
@@ -11,8 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ergochat/readline/internal/ansi"
-	"github.com/ergochat/readline/internal/platform"
+	"github.com/cogentcore/readline/internal/ansi"
+	"github.com/cogentcore/readline/internal/platform"
 )
 
 const (

--- a/undo.go
+++ b/undo.go
@@ -1,7 +1,7 @@
 package readline
 
 import (
-	"github.com/ergochat/readline/internal/ringbuf"
+	"github.com/cogentcore/readline/internal/ringbuf"
 )
 
 type undoEntry struct {

--- a/utils.go
+++ b/utils.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/ergochat/readline/internal/term"
+	"github.com/cogentcore/readline/internal/term"
 )
 
 const (


### PR DESCRIPTION
This allows readline to be built under wasm (js).  It is just a copy of the windows version which is mostly stubbed it seems. It works to allow building but I was not able to test actual functionality yet.
