### PR TITLE
Fix: Ensure constant format strings in fmt and printf calls

### DIFF
--- a/history.go
+++ b/history.go
@@ -3,7 +3,6 @@ package readline
 import (
 	"bufio"
 	"container/list"
-	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -236,7 +235,7 @@ func (o *opHistory) Enable() {
 func (o *opHistory) debug() {
 	debugPrint("-------")
 	for item := o.history.Front(); item != nil; item = item.Next() {
-		debugPrint(fmt.Sprintf("%+v", item.Value))
+		debugPrint("%+v", item.Value)
 	}
 }
 


### PR DESCRIPTION
Go 1.24 introduces stricter checks for format string validation. This commit fixes instances where non-constant format strings were used in calls to functions like `fmt.Errorf`, `fmt.Printf`, and similar.